### PR TITLE
Restore tile layer

### DIFF
--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -10,4 +10,5 @@ export {Popup} from './Popup.js';
 export {Tooltip} from './Tooltip.js';
 
 export * from './marker/index.js';
+export * from './tile/index.js';
 export * from './vector/index.js';


### PR DESCRIPTION
This is needed in order to properly implement tiles on DataMaps.